### PR TITLE
Simplify configuration, make sure extension can be fully disabled

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,19 +1,290 @@
-= globalID IRIS
+= IRIS Quarkus Extension
 
 Iris is a framework for enabling event driven architecture for microservices.
 
-== Instructions
 
-Compile and test the project:
+:summaryTableId: quarkus-iris
+[.configuration-legend]
+icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
+[.configuration-reference.searchable, cols="80,.^10,.^10"]
+|===
 
-[source,bash]
-----
-mvn verify
-----
+h|[[quarkus-iris_configuration]]link:#quarkus-iris_configuration[Configuration property]
 
-=== Project structure
+h|Type
+h|Default
 
-* link:extension/[] - Quarkus Extension
-* link:maven/[] - Maven plugins
-* link:asyncapi/[] - Asyncapi tooling
+a|icon:lock[title=Fixed at build time] [[quarkus-iris_quarkus.iris.enabled]]`link:#quarkus-iris_quarkus.iris.enabled[quarkus.iris.enabled]`
 
+
+[.description]
+--
+disable initialization of consumers
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRIS_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRIS_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean
+|`true`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-iris_quarkus.iris.liveness-check-enabled]]`link:#quarkus-iris_quarkus.iris.liveness-check-enabled[quarkus.iris.liveness-check-enabled]`
+
+
+[.description]
+--
+Enable or disable extension liveness health check
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRIS_LIVENESS_CHECK_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRIS_LIVENESS_CHECK_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean
+|`true`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-iris_quarkus.iris.readiness-check-enabled]]`link:#quarkus-iris_quarkus.iris.readiness-check-enabled[quarkus.iris.readiness-check-enabled]`
+
+
+[.description]
+--
+Enable or disable extension readiness helath check
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRIS_READINESS_CHECK_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRIS_READINESS_CHECK_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--|boolean
+|`true`
+
+
+a| [[quarkus-iris_quarkus.iris.backoff-interval-millis]]`link:#quarkus-iris_quarkus.iris.backoff-interval-millis[quarkus.iris.backoff-interval-millis]`
+
+
+[.description]
+--
+Connection retry initial backoff interval
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRIS_BACKOFF_INTERVAL_MILLIS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRIS_BACKOFF_INTERVAL_MILLIS+++`
+endif::add-copy-button-to-env-var[]
+--|long
+|`1000`
+
+
+a| [[quarkus-iris_quarkus.iris.backoff-multiplier]]`link:#quarkus-iris_quarkus.iris.backoff-multiplier[quarkus.iris.backoff-multiplier]`
+
+
+[.description]
+--
+Connection retry backoff multiplier
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRIS_BACKOFF_MULTIPLIER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRIS_BACKOFF_MULTIPLIER+++`
+endif::add-copy-button-to-env-var[]
+--|double
+|`1.5`
+
+
+a| [[quarkus-iris_quarkus.iris.max-retries]]`link:#quarkus-iris_quarkus.iris.max-retries[quarkus.iris.max-retries]`
+
+
+[.description]
+--
+Connection max retries
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRIS_MAX_RETRIES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRIS_MAX_RETRIES+++`
+endif::add-copy-button-to-env-var[]
+--|int
+|`10`
+
+
+a| [[quarkus-iris_quarkus.iris.confirmation-batch-size]]`link:#quarkus-iris_quarkus.iris.confirmation-batch-size[quarkus.iris.confirmation-batch-size]`
+
+
+[.description]
+--
+Number of messages to batch for delivery confirmation
+
+Set to 1 for immediate confirmation of each message. Set to 0 for no confirmations.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRIS_CONFIRMATION_BATCH_SIZE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRIS_CONFIRMATION_BATCH_SIZE+++`
+endif::add-copy-button-to-env-var[]
+--|long
+|`1`
+
+
+a| [[quarkus-iris_quarkus.iris.retry-max-count]]`link:#quarkus-iris_quarkus.iris.retry-max-count[quarkus.iris.retry-max-count]`
+
+
+[.description]
+--
+Number of retries for Iris messages
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRIS_RETRY_MAX_COUNT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRIS_RETRY_MAX_COUNT+++`
+endif::add-copy-button-to-env-var[]
+--|int
+|`3`
+
+
+a| [[quarkus-iris_quarkus.iris.rpc.timeout]]`link:#quarkus-iris_quarkus.iris.rpc.timeout[quarkus.iris.rpc.timeout]`
+
+
+[.description]
+--
+Iris RPC request timeout
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRIS_RPC_TIMEOUT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRIS_RPC_TIMEOUT+++`
+endif::add-copy-button-to-env-var[]
+--|int
+|`2000`
+
+
+a| [[quarkus-iris_quarkus.iris.rabbitmq-host]]`link:#quarkus-iris_quarkus.iris.rabbitmq-host[quarkus.iris.rabbitmq-host]`
+
+
+[.description]
+--
+RabbitMQ broker host
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRIS_RABBITMQ_HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRIS_RABBITMQ_HOST+++`
+endif::add-copy-button-to-env-var[]
+--|string
+|`${rabbitmq-host:localhost}`
+
+
+a| [[quarkus-iris_quarkus.iris.rabbitmq-protocol]]`link:#quarkus-iris_quarkus.iris.rabbitmq-protocol[quarkus.iris.rabbitmq-protocol]`
+
+
+[.description]
+--
+RabbitMQ protocol (amqp/amqps)
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRIS_RABBITMQ_PROTOCOL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRIS_RABBITMQ_PROTOCOL+++`
+endif::add-copy-button-to-env-var[]
+--|string
+|`${rabbitmq-protocol}`
+
+
+a| [[quarkus-iris_quarkus.iris.rabbitmq-port]]`link:#quarkus-iris_quarkus.iris.rabbitmq-port[quarkus.iris.rabbitmq-port]`
+
+
+[.description]
+--
+RabbitMQ port
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRIS_RABBITMQ_PORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRIS_RABBITMQ_PORT+++`
+endif::add-copy-button-to-env-var[]
+--|int
+|`${rabbitmq-port}`
+
+
+a| [[quarkus-iris_quarkus.iris.rabbitmq-ssl]]`link:#quarkus-iris_quarkus.iris.rabbitmq-ssl[quarkus.iris.rabbitmq-ssl]`
+
+
+[.description]
+--
+Use ssl for RabbitMQ broker connection
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRIS_RABBITMQ_SSL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRIS_RABBITMQ_SSL+++`
+endif::add-copy-button-to-env-var[]
+--|boolean
+|`${rabbitmq-ssl}`
+
+
+a| [[quarkus-iris_quarkus.iris.rabbitmq-username]]`link:#quarkus-iris_quarkus.iris.rabbitmq-username[quarkus.iris.rabbitmq-username]`
+
+
+[.description]
+--
+RabbitMQ broker username
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRIS_RABBITMQ_USERNAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRIS_RABBITMQ_USERNAME+++`
+endif::add-copy-button-to-env-var[]
+--|string
+|`${rabbitmq-username:guest}`
+
+
+a| [[quarkus-iris_quarkus.iris.rabbitmq-password]]`link:#quarkus-iris_quarkus.iris.rabbitmq-password[quarkus.iris.rabbitmq-password]`
+
+
+[.description]
+--
+RabbitMQ broker password
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRIS_RABBITMQ_PASSWORD+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRIS_RABBITMQ_PASSWORD+++`
+endif::add-copy-button-to-env-var[]
+--|string
+|`${rabbitmq-password:guest}`
+
+
+a| [[quarkus-iris_quarkus.iris.rabbitmq-virtual-host]]`link:#quarkus-iris_quarkus.iris.rabbitmq-virtual-host[quarkus.iris.rabbitmq-virtual-host]`
+
+
+[.description]
+--
+RabbitMQ broker virtual host
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRIS_RABBITMQ_VIRTUAL_HOST+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRIS_RABBITMQ_VIRTUAL_HOST+++`
+endif::add-copy-button-to-env-var[]
+--|string
+|`${rabbitmq-virtual-host:/}`
+
+|===

--- a/common/src/main/java/org/iris_events/annotations/Message.java
+++ b/common/src/main/java/org/iris_events/annotations/Message.java
@@ -74,7 +74,8 @@ public @interface Message {
      * Defines the type of RPC response for this message.
      *
      * This is used only in RPC style messages and is redundant otherwise.
-     * This *needs* to be defined in the "request" message that will be used to call {@link org.iris_events.producer.EventProducer#sendAndReceive(Object, Class)}
+     * This *needs* to be defined in the "request" message that will be used to call
+     * {@link org.iris_events.producer.EventProducer#sendAndReceive(Object, Class)}
      * Value of {@link Message#rpcResponse()} must also be a class annotated with the {@link Message} annotation
      */
     Class<?> rpcResponse() default Void.class;

--- a/extension/deployment/src/main/java/org/iris_events/deployment/IrisEnabled.java
+++ b/extension/deployment/src/main/java/org/iris_events/deployment/IrisEnabled.java
@@ -1,0 +1,19 @@
+package org.iris_events.deployment;
+
+import java.util.function.BooleanSupplier;
+
+import org.iris_events.runtime.configuration.IrisBuildTimeConfig;
+
+public class IrisEnabled implements BooleanSupplier {
+
+    private final IrisBuildTimeConfig config;
+
+    public IrisEnabled(IrisBuildTimeConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public boolean getAsBoolean() {
+        return config.enabled;
+    }
+}

--- a/extension/integration-test-quarkus/src/test/java/org/iris_events/it/rpc/ExtensionDisabledTest.java
+++ b/extension/integration-test-quarkus/src/test/java/org/iris_events/it/rpc/ExtensionDisabledTest.java
@@ -1,0 +1,28 @@
+package org.iris_events.it.rpc;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.iris_events.consumer.ConsumerContainer;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ExtensionDisabledTest {
+    @RegisterExtension
+    static final QuarkusUnitTest TEST = new QuarkusUnitTest()
+            .withEmptyApplication()
+            .overrideConfigKey("quarkus.iris.enabled", "false");
+
+    @Inject
+    Instance<ConsumerContainer> consumerContainers;
+
+    @Test
+    public void testConfig() {
+
+        Assertions.assertTrue(consumerContainers.isUnsatisfied(), "Extension should not load any IRIS services");
+    }
+
+}

--- a/extension/integration-tests/src/test/java/org/iris_events/it/EventsMalformedIT.java
+++ b/extension/integration-tests/src/test/java/org/iris_events/it/EventsMalformedIT.java
@@ -19,7 +19,7 @@ import org.iris_events.runtime.ExchangeNameProvider;
 import org.iris_events.runtime.QueueNameProvider;
 import org.iris_events.runtime.RpcMappingProvider;
 import org.iris_events.runtime.channel.ChannelService;
-import org.iris_events.runtime.configuration.IrisRabbitMQConfig;
+import org.iris_events.runtime.configuration.IrisConfig;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,7 +46,7 @@ public class EventsMalformedIT extends IsolatedEventContextTest {
     ChannelService producerChannelService;
 
     @Inject
-    IrisRabbitMQConfig resilienceConfig;
+    IrisConfig resilienceConfig;
 
     @Inject
     TransactionManager transactionManager;

--- a/extension/runtime/src/main/java/org/iris_events/producer/EventProducer.java
+++ b/extension/runtime/src/main/java/org/iris_events/producer/EventProducer.java
@@ -47,7 +47,7 @@ import org.iris_events.runtime.QueueNameProvider;
 import org.iris_events.runtime.RpcMappingProvider;
 import org.iris_events.runtime.channel.ChannelKey;
 import org.iris_events.runtime.channel.ChannelService;
-import org.iris_events.runtime.configuration.IrisRabbitMQConfig;
+import org.iris_events.runtime.configuration.IrisConfig;
 import org.iris_events.tx.TransactionCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,7 +70,7 @@ public class EventProducer {
     private final ChannelService channelService;
     private final ObjectMapper objectMapper;
     private final EventContext eventContext;
-    private final IrisRabbitMQConfig config;
+    private final IrisConfig config;
     private final TransactionManager transactionManager;
     private final BasicPropertiesProvider basicPropertiesProvider;
     private final QueueNameProvider queueNameProvider;
@@ -89,7 +89,7 @@ public class EventProducer {
     public EventProducer(@Named("producerChannelService") ChannelService channelService,
             ObjectMapper objectMapper,
             EventContext eventContext,
-            IrisRabbitMQConfig config,
+            IrisConfig config,
             TransactionManager transactionManager,
             BasicPropertiesProvider basicPropertiesProvider,
             ExchangeNameProvider exchangeNameProvider,

--- a/extension/runtime/src/main/java/org/iris_events/runtime/channel/AbstractChannelService.java
+++ b/extension/runtime/src/main/java/org/iris_events/runtime/channel/AbstractChannelService.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 
-import org.iris_events.runtime.configuration.IrisRabbitMQConfig;
+import org.iris_events.runtime.configuration.IrisConfig;
 import org.iris_events.runtime.connection.AbstractConnectionProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,13 +19,13 @@ public abstract class AbstractChannelService implements ChannelService, Shutdown
     private final static Logger log = LoggerFactory.getLogger(AbstractChannelService.class);
     private final ConcurrentHashMap<String, Channel> channelMap = new ConcurrentHashMap<>();
     private AbstractConnectionProvider connectionProvider;
-    private IrisRabbitMQConfig config;
+    private IrisConfig config;
 
     @SuppressWarnings("unused")
     protected AbstractChannelService() {
     }
 
-    protected AbstractChannelService(AbstractConnectionProvider connectionProvider, IrisRabbitMQConfig config) {
+    protected AbstractChannelService(AbstractConnectionProvider connectionProvider, IrisConfig config) {
         this.connectionProvider = connectionProvider;
         this.config = config;
     }

--- a/extension/runtime/src/main/java/org/iris_events/runtime/channel/ConsumerChannelService.java
+++ b/extension/runtime/src/main/java/org/iris_events/runtime/channel/ConsumerChannelService.java
@@ -4,14 +4,14 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
-import org.iris_events.runtime.configuration.IrisRabbitMQConfig;
+import org.iris_events.runtime.configuration.IrisConfig;
 import org.iris_events.runtime.connection.ConsumerConnectionProvider;
 
 @Named("consumerChannelService")
 @ApplicationScoped()
 public class ConsumerChannelService extends AbstractChannelService {
     @Inject
-    public ConsumerChannelService(ConsumerConnectionProvider connectionProvider, IrisRabbitMQConfig config) {
+    public ConsumerChannelService(ConsumerConnectionProvider connectionProvider, IrisConfig config) {
         super(connectionProvider, config);
     }
 }

--- a/extension/runtime/src/main/java/org/iris_events/runtime/channel/ProducerChannelService.java
+++ b/extension/runtime/src/main/java/org/iris_events/runtime/channel/ProducerChannelService.java
@@ -4,14 +4,14 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
-import org.iris_events.runtime.configuration.IrisRabbitMQConfig;
+import org.iris_events.runtime.configuration.IrisConfig;
 import org.iris_events.runtime.connection.ProducerConnectionProvider;
 
 @Named("producerChannelService")
 @ApplicationScoped
 public class ProducerChannelService extends AbstractChannelService {
     @Inject
-    public ProducerChannelService(ProducerConnectionProvider connectionProvider, IrisRabbitMQConfig config) {
+    public ProducerChannelService(ProducerConnectionProvider connectionProvider, IrisConfig config) {
         super(connectionProvider, config);
     }
 }

--- a/extension/runtime/src/main/java/org/iris_events/runtime/configuration/IrisBuildTimeConfig.java
+++ b/extension/runtime/src/main/java/org/iris_events/runtime/configuration/IrisBuildTimeConfig.java
@@ -4,8 +4,8 @@ import io.quarkus.runtime.annotations.ConfigItem;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
-@ConfigRoot(name = "iris", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
-public final class IrisBuildConfiguration {
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+public final class IrisBuildTimeConfig {
     /**
      * disable initialization of consumers
      */

--- a/extension/runtime/src/main/java/org/iris_events/runtime/configuration/IrisConfig.java
+++ b/extension/runtime/src/main/java/org/iris_events/runtime/configuration/IrisConfig.java
@@ -2,29 +2,29 @@ package org.iris_events.runtime.configuration;
 
 import java.util.Optional;
 
-import jakarta.inject.Singleton;
+import io.quarkus.runtime.annotations.ConfigItem;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
-@Singleton
-public class IrisRabbitMQConfig {
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public class IrisConfig {
 
     /**
      * Connection retry initial backoff interval
      */
-    @ConfigProperty(name = "iris.backoff-interval-millis", defaultValue = "1000")
+    @ConfigItem(name = "backoff-interval-millis", defaultValue = "1000")
     long backoffIntervalMillis;
 
     /**
      * Connection retry backoff multiplier
      */
-    @ConfigProperty(name = "iris.backoff-multiplier", defaultValue = "1.5")
+    @ConfigItem(name = "backoff-multiplier", defaultValue = "1.5")
     double backoffMultiplier;
 
     /**
      * Connection max retries
      */
-    @ConfigProperty(name = "iris.max-retries", defaultValue = "10")
+    @ConfigItem(name = "max-retries", defaultValue = "10")
     int maxRetries;
 
     /**
@@ -33,68 +33,68 @@ public class IrisRabbitMQConfig {
      * Set to 1 for immediate confirmation of each message.
      * Set to 0 for no confirmations.
      */
-    @ConfigProperty(name = "iris.confirmation-batch-size", defaultValue = "1")
+    @ConfigItem(name = "confirmation-batch-size", defaultValue = "1")
     long confirmationBatchSize;
 
     /**
      * Number of retries for Iris messages
      */
-    @ConfigProperty(name = "iris.retry-max-count", defaultValue = "3")
+    @ConfigItem(name = "retry-max-count", defaultValue = "3")
     int retryMaxCount;
 
     /**
      * Iris RPC request timeout
      */
-    @ConfigProperty(name = "iris.rpc.timeout", defaultValue = "2000")
+    @ConfigItem(name = "rpc.timeout", defaultValue = "2000")
     int rpcTimeout;
 
     /**
      * RabbitMQ broker host
      */
-    @ConfigProperty(name = "rabbitmq-host", defaultValue = "localhost")
+    @ConfigItem(name = "rabbitmq-host", defaultValue = "${rabbitmq-host:localhost}")
     String host;
 
     /**
      * RabbitMQ protocol (amqp/amqps)
      */
-    @ConfigProperty(name = "rabbitmq-protocol")
+    @ConfigItem(name = "rabbitmq-protocol", defaultValue = "${rabbitmq-protocol}")
     Optional<String> protocol;
 
     /**
      * RabbitMQ port
      */
-    @ConfigProperty(name = "rabbitmq-port")
+    @ConfigItem(name = "rabbitmq-port", defaultValue = "${rabbitmq-port}")
     Optional<Integer> port;
 
     /**
      * Use ssl for RabbitMQ broker connection
      */
-    @ConfigProperty(name = "rabbitmq-ssl")
+    @ConfigItem(name = "rabbitmq-ssl", defaultValue = "${rabbitmq-ssl}")
     Optional<Boolean> ssl;
 
     /**
      * RabbitMQ broker username
      */
-    @ConfigProperty(name = "rabbitmq-username", defaultValue = "guest")
+    @ConfigItem(name = "rabbitmq-username", defaultValue = "${rabbitmq-username:guest}")
     String username;
 
     /**
      * RabbitMQ broker password
      */
-    @ConfigProperty(name = "rabbitmq-password", defaultValue = "guest")
+    @ConfigItem(name = "rabbitmq-password", defaultValue = "${rabbitmq-password:guest}")
     String password;
 
     /**
      * RabbitMQ broker virtual host
      */
-    @ConfigProperty(name = "rabbitmq-virtual-host", defaultValue = "/")
+    @ConfigItem(name = "rabbitmq-virtual-host", defaultValue = "${rabbitmq-virtual-host:/}")
     String virtualHost;
 
     public long getBackoffIntervalMillis() {
         return backoffIntervalMillis;
     }
 
-    public IrisRabbitMQConfig setBackoffIntervalMillis(final long backoffIntervalMillis) {
+    public IrisConfig setBackoffIntervalMillis(final long backoffIntervalMillis) {
         this.backoffIntervalMillis = backoffIntervalMillis;
         return this;
     }
@@ -103,7 +103,7 @@ public class IrisRabbitMQConfig {
         return backoffMultiplier;
     }
 
-    public IrisRabbitMQConfig setBackoffMultiplier(final double backoffMultiplier) {
+    public IrisConfig setBackoffMultiplier(final double backoffMultiplier) {
         this.backoffMultiplier = backoffMultiplier;
         return this;
     }
@@ -112,7 +112,7 @@ public class IrisRabbitMQConfig {
         return maxRetries;
     }
 
-    public IrisRabbitMQConfig setMaxRetries(final int maxRetries) {
+    public IrisConfig setMaxRetries(final int maxRetries) {
         this.maxRetries = maxRetries;
         return this;
     }
@@ -121,7 +121,7 @@ public class IrisRabbitMQConfig {
         return confirmationBatchSize;
     }
 
-    public IrisRabbitMQConfig setConfirmationBatchSize(final long confirmationBatchSize) {
+    public IrisConfig setConfirmationBatchSize(final long confirmationBatchSize) {
         this.confirmationBatchSize = confirmationBatchSize;
         return this;
     }
@@ -130,7 +130,7 @@ public class IrisRabbitMQConfig {
         return retryMaxCount;
     }
 
-    public IrisRabbitMQConfig setRetryMaxCount(final int retryMaxCount) {
+    public IrisConfig setRetryMaxCount(final int retryMaxCount) {
         this.retryMaxCount = retryMaxCount;
         return this;
     }
@@ -139,7 +139,7 @@ public class IrisRabbitMQConfig {
         return host;
     }
 
-    public IrisRabbitMQConfig setHost(final String host) {
+    public IrisConfig setHost(final String host) {
         this.host = host;
         return this;
     }
@@ -148,7 +148,7 @@ public class IrisRabbitMQConfig {
         return protocol;
     }
 
-    public IrisRabbitMQConfig setProtocol(final String protocol) {
+    public IrisConfig setProtocol(final String protocol) {
         this.protocol = Optional.ofNullable(protocol);
         return this;
     }
@@ -161,7 +161,7 @@ public class IrisRabbitMQConfig {
         }).orElseGet(() -> port.orElse(5672));
     }
 
-    public IrisRabbitMQConfig setPort(final int port) {
+    public IrisConfig setPort(final int port) {
         this.port = Optional.of(port);
         return this;
     }
@@ -174,7 +174,7 @@ public class IrisRabbitMQConfig {
         }).orElseGet(() -> ssl.orElse(false));
     }
 
-    public IrisRabbitMQConfig setSsl(final boolean ssl) {
+    public IrisConfig setSsl(final boolean ssl) {
         this.ssl = Optional.of(ssl);
         return this;
     }
@@ -183,7 +183,7 @@ public class IrisRabbitMQConfig {
         return username;
     }
 
-    public IrisRabbitMQConfig setUsername(final String username) {
+    public IrisConfig setUsername(final String username) {
         this.username = username;
         return this;
     }
@@ -192,7 +192,7 @@ public class IrisRabbitMQConfig {
         return password;
     }
 
-    public IrisRabbitMQConfig setPassword(final String password) {
+    public IrisConfig setPassword(final String password) {
         this.password = password;
         return this;
     }
@@ -201,7 +201,7 @@ public class IrisRabbitMQConfig {
         return virtualHost;
     }
 
-    public IrisRabbitMQConfig setVirtualHost(final String virtualHost) {
+    public IrisConfig setVirtualHost(final String virtualHost) {
         this.virtualHost = virtualHost;
         return this;
     }

--- a/extension/runtime/src/main/java/org/iris_events/runtime/connection/AbstractConnectionProvider.java
+++ b/extension/runtime/src/main/java/org/iris_events/runtime/connection/AbstractConnectionProvider.java
@@ -8,7 +8,7 @@ import org.iris_events.exception.IrisConnectionException;
 import org.iris_events.health.IrisLivenessCheck;
 import org.iris_events.health.IrisReadinessCheck;
 import org.iris_events.runtime.InstanceInfoProvider;
-import org.iris_events.runtime.configuration.IrisRabbitMQConfig;
+import org.iris_events.runtime.configuration.IrisConfig;
 import org.slf4j.Logger;
 
 import com.rabbitmq.client.Connection;
@@ -20,7 +20,7 @@ import io.github.resilience4j.retry.RetryConfig;
 public abstract class AbstractConnectionProvider {
     private ConnectionFactoryProvider connectionFactoryProvider;
     private InstanceInfoProvider instanceInfoProvider;
-    private IrisRabbitMQConfig config;
+    private IrisConfig config;
     private IrisReadinessCheck readinessCheck;
     private IrisLivenessCheck livenessCheck;
     private Logger log;
@@ -32,7 +32,7 @@ public abstract class AbstractConnectionProvider {
     }
 
     public AbstractConnectionProvider(ConnectionFactoryProvider connectionFactoryProvider,
-            InstanceInfoProvider instanceInfoProvider, IrisRabbitMQConfig config, IrisReadinessCheck readinessCheck,
+            InstanceInfoProvider instanceInfoProvider, IrisConfig config, IrisReadinessCheck readinessCheck,
             IrisLivenessCheck livenessCheck, Logger log) {
         this.connectionFactoryProvider = connectionFactoryProvider;
         this.instanceInfoProvider = instanceInfoProvider;

--- a/extension/runtime/src/main/java/org/iris_events/runtime/connection/ConnectionFactoryProvider.java
+++ b/extension/runtime/src/main/java/org/iris_events/runtime/connection/ConnectionFactoryProvider.java
@@ -9,7 +9,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import org.iris_events.exception.IrisConnectionFactoryException;
-import org.iris_events.runtime.configuration.IrisRabbitMQConfig;
+import org.iris_events.runtime.configuration.IrisConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,12 +20,12 @@ public class ConnectionFactoryProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConnectionFactoryProvider.class);
 
-    private final IrisRabbitMQConfig config;
+    private final IrisConfig config;
 
     private ConnectionFactory connectionFactory;
 
     @Inject
-    public ConnectionFactoryProvider(IrisRabbitMQConfig config) {
+    public ConnectionFactoryProvider(IrisConfig config) {
         this.config = config;
     }
 
@@ -37,7 +37,7 @@ public class ConnectionFactoryProvider {
         });
     }
 
-    private ConnectionFactory buildConnectionFactory(IrisRabbitMQConfig config) {
+    private ConnectionFactory buildConnectionFactory(IrisConfig config) {
         int port = config.getPort();
         String vhost = config.getVirtualHost();
 

--- a/extension/runtime/src/main/java/org/iris_events/runtime/connection/ConsumerConnectionProvider.java
+++ b/extension/runtime/src/main/java/org/iris_events/runtime/connection/ConsumerConnectionProvider.java
@@ -6,7 +6,7 @@ import jakarta.inject.Inject;
 import org.iris_events.health.IrisLivenessCheck;
 import org.iris_events.health.IrisReadinessCheck;
 import org.iris_events.runtime.InstanceInfoProvider;
-import org.iris_events.runtime.configuration.IrisRabbitMQConfig;
+import org.iris_events.runtime.configuration.IrisConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,7 +17,7 @@ public class ConsumerConnectionProvider extends AbstractConnectionProvider {
 
     @Inject
     public ConsumerConnectionProvider(ConnectionFactoryProvider connectionFactoryProvider,
-            InstanceInfoProvider instanceInfoProvider, IrisRabbitMQConfig config, IrisReadinessCheck readinessCheck,
+            InstanceInfoProvider instanceInfoProvider, IrisConfig config, IrisReadinessCheck readinessCheck,
             IrisLivenessCheck livenessCheck) {
         super(connectionFactoryProvider, instanceInfoProvider, config, readinessCheck, livenessCheck, log);
     }

--- a/extension/runtime/src/main/java/org/iris_events/runtime/connection/ProducerConnectionProvider.java
+++ b/extension/runtime/src/main/java/org/iris_events/runtime/connection/ProducerConnectionProvider.java
@@ -7,7 +7,7 @@ import jakarta.inject.Inject;
 import org.iris_events.health.IrisLivenessCheck;
 import org.iris_events.health.IrisReadinessCheck;
 import org.iris_events.runtime.InstanceInfoProvider;
-import org.iris_events.runtime.configuration.IrisRabbitMQConfig;
+import org.iris_events.runtime.configuration.IrisConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,7 +21,7 @@ public class ProducerConnectionProvider extends AbstractConnectionProvider {
 
     @Inject
     public ProducerConnectionProvider(ConnectionFactoryProvider connectionFactoryProvider,
-            InstanceInfoProvider instanceInfoProvider, IrisRabbitMQConfig config, IrisReadinessCheck readinessCheck,
+            InstanceInfoProvider instanceInfoProvider, IrisConfig config, IrisReadinessCheck readinessCheck,
             IrisLivenessCheck livenessCheck) {
         super(connectionFactoryProvider, instanceInfoProvider, config, readinessCheck, livenessCheck, log);
     }

--- a/extension/runtime/src/main/java/org/iris_events/runtime/requeue/MessageRequeueHandler.java
+++ b/extension/runtime/src/main/java/org/iris_events/runtime/requeue/MessageRequeueHandler.java
@@ -27,7 +27,7 @@ import org.iris_events.exception.MessagingException;
 import org.iris_events.runtime.QueueNameProvider;
 import org.iris_events.runtime.TimestampProvider;
 import org.iris_events.runtime.channel.ChannelService;
-import org.iris_events.runtime.configuration.IrisRabbitMQConfig;
+import org.iris_events.runtime.configuration.IrisConfig;
 
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
@@ -37,13 +37,13 @@ import com.rabbitmq.client.Delivery;
 public class MessageRequeueHandler {
 
     private final Channel channel;
-    private final IrisRabbitMQConfig config;
+    private final IrisConfig config;
     private final QueueNameProvider queueNameProvider;
     private final TimestampProvider timestampProvider;
 
     @Inject
     public MessageRequeueHandler(@Named("producerChannelService") ChannelService channelService,
-            IrisRabbitMQConfig config,
+            IrisConfig config,
             QueueNameProvider queueNameProvider, TimestampProvider timestampProvider) throws IOException {
         this.config = config;
         this.queueNameProvider = queueNameProvider;

--- a/extension/runtime/src/test/java/org/iris_events/runtime/channel/AbstractChannelServiceTest.java
+++ b/extension/runtime/src/test/java/org/iris_events/runtime/channel/AbstractChannelServiceTest.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.iris_events.runtime.channel.mock.MockConnection;
-import org.iris_events.runtime.configuration.IrisRabbitMQConfig;
+import org.iris_events.runtime.configuration.IrisConfig;
 import org.iris_events.runtime.connection.ConsumerConnectionProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,16 +17,16 @@ import org.mockito.Mockito;
 class AbstractChannelServiceTest {
 
     private ChannelService channelService;
-    private IrisRabbitMQConfig irisRabbitMQConfigMock;
+    private IrisConfig irisConfigMock;
     private ConsumerConnectionProvider connectionProviderMock;
     private AtomicInteger closeCount;
 
     @BeforeEach
     public void setup() {
-        this.irisRabbitMQConfigMock = Mockito.mock(IrisRabbitMQConfig.class);
+        this.irisConfigMock = Mockito.mock(IrisConfig.class);
         this.connectionProviderMock = Mockito.mock(ConsumerConnectionProvider.class);
 
-        this.channelService = new TestChannelService(connectionProviderMock, irisRabbitMQConfigMock);
+        this.channelService = new TestChannelService(connectionProviderMock, irisConfigMock);
         this.closeCount = new AtomicInteger();
     }
 

--- a/extension/runtime/src/test/java/org/iris_events/runtime/channel/TestChannelService.java
+++ b/extension/runtime/src/test/java/org/iris_events/runtime/channel/TestChannelService.java
@@ -2,13 +2,13 @@ package org.iris_events.runtime.channel;
 
 import jakarta.inject.Inject;
 
-import org.iris_events.runtime.configuration.IrisRabbitMQConfig;
+import org.iris_events.runtime.configuration.IrisConfig;
 import org.iris_events.runtime.connection.ConsumerConnectionProvider;
 
 public class TestChannelService extends AbstractChannelService {
 
     @Inject
-    public TestChannelService(ConsumerConnectionProvider connectionProvider, IrisRabbitMQConfig config) {
+    public TestChannelService(ConsumerConnectionProvider connectionProvider, IrisConfig config) {
         super(connectionProvider, config);
     }
 }

--- a/extension/runtime/src/test/java/org/iris_events/runtime/connection/ConnectionFactoryProviderTest.java
+++ b/extension/runtime/src/test/java/org/iris_events/runtime/connection/ConnectionFactoryProviderTest.java
@@ -4,14 +4,14 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import org.iris_events.runtime.configuration.IrisRabbitMQConfig;
+import org.iris_events.runtime.configuration.IrisConfig;
 import org.junit.jupiter.api.Test;
 
 class ConnectionFactoryProviderTest {
 
     @Test
     void shouldSetAllProperties() {
-        final IrisRabbitMQConfig irisConfiguration = new IrisRabbitMQConfig();
+        final IrisConfig irisConfiguration = new IrisConfig();
 
         final var username = "username.mock";
         final var password = "password.mock";
@@ -43,7 +43,7 @@ class ConnectionFactoryProviderTest {
         final var password = "p@$$word.m//ck";
         final var port = 5432;
 
-        final IrisRabbitMQConfig irisConfiguration = new IrisRabbitMQConfig()
+        final IrisConfig irisConfiguration = new IrisConfig()
                 .setUsername(username)
                 .setPassword(password)
                 .setPort(port)

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
         <connection>scm:git:git@github.com:iris-events/iris.git</connection>
         <developerConnection>scm:git:git@github.com:iris-events/iris.git</developerConnection>
         <url>https://github.com/iris-events/iris</url>
-      <tag>v5.0.8</tag>
   </scm>
     <!--
     sort poms
@@ -38,7 +37,7 @@
         <version.httpclient>4.5.14</version.httpclient>
         <version.jackson>2.15.2</version.jackson>
         <version.jakarta.annotations>2.1.1</version.jakarta.annotations>
-        <version.jandex>3.1.5</version.jandex>
+        <version.jandex>3.1.6</version.jandex>
         <version.jsonschema2pojo-core>1.2.1</version.jsonschema2pojo-core>
         <version.junit>5.10.0</version.junit>
         <version.maven>3.9.4</version.maven>
@@ -54,7 +53,7 @@
         <version.org.skyscreamer>1.5.1</version.org.skyscreamer>
         <!-- plugin dependencies -->
 
-        <version.quarkus>3.2.7.Final</version.quarkus>
+        <version.quarkus>3.2.9.Final</version.quarkus>
         <version.rabbit.amqp-client>5.16.1</version.rabbit.amqp-client>
         <version.resilience4j-retry>2.1.0</version.resilience4j-retry>
         <version.slf4j-api>2.0.7</version.slf4j-api>


### PR DESCRIPTION
This pull request includes a significant number of changes to improve the IRIS Quarkus extension. The most important changes include adding new configuration properties to the `README.adoc`, renaming the `EventMessagingProcessor` class to `IrisProcessor` and making various changes to method annotations and parameter types in `IrisProcessor.java`, and adding a test class `ExtensionDisabledTest` to verify that the IRIS extension does not load any IRIS services when the `quarkus.iris.enabled` property is set to `false`.

Main interface changes:

* [`README.adoc`](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124L1-R290): Added new configuration properties to control various features and connection retry intervals.
* [`extension/deployment/src/main/java/org/iris_events/deployment/IrisProcessor.java`](diffhunk://#diff-31d0c92c67f9d5872de1ff32a5827d397f4291f5fd371854732c38ab40e05777L58-R77): Renamed the `EventMessagingProcessor` class to `IrisProcessor` and made various changes to method annotations and parameter types. [[1]](diffhunk://#diff-31d0c92c67f9d5872de1ff32a5827d397f4291f5fd371854732c38ab40e05777L58-R77) [[2]](diffhunk://#diff-31d0c92c67f9d5872de1ff32a5827d397f4291f5fd371854732c38ab40e05777L353-R341) [[3]](diffhunk://#diff-31d0c92c67f9d5872de1ff32a5827d397f4291f5fd371854732c38ab40e05777L326-R314) [[4]](diffhunk://#diff-31d0c92c67f9d5872de1ff32a5827d397f4291f5fd371854732c38ab40e05777L231-R217) [[5]](diffhunk://#diff-31d0c92c67f9d5872de1ff32a5827d397f4291f5fd371854732c38ab40e05777L195-R181) [[6]](diffhunk://#diff-31d0c92c67f9d5872de1ff32a5827d397f4291f5fd371854732c38ab40e05777L148-R134)
* [`extension/integration-test-quarkus/src/test/java/org/iris_events/it/rpc/ExtensionDisabledTest.java`](diffhunk://#diff-bcc5b54b28e559569ea16bc972853228955fba96871297a8e60321457a8213d9R1-R28): Added a test class to verify that the IRIS extension does not load any IRIS services when the `quarkus.iris.enabled` property is set to `false`.

Other important changes:

* [`extension/deployment/src/main/java/org/iris_events/deployment/IrisEnabled.java`](diffhunk://#diff-cfdefafb1190eacda134fba1143d8c798f5e736aeac6f7e074c7943e224315d7R1-R19): Added a new class `IrisEnabled` to return the value of the `enabled` field in the `config` object.
* [`extension/runtime/src/main/java/org/iris_events/runtime/channel/ConsumerChannelService.java`](diffhunk://#diff-173cde5d145330d106cff5a4454166b87c17f708b1d8325969357e7d5a8d6c03L7-R14): Updated the constructor to accept an `IrisConfig` object instead of an `IrisRabbitMQConfig` object.
* [`extension/runtime/src/main/java/org/iris_events/runtime/connection/ConnectionFactoryProvider.java`](diffhunk://#diff-af0b87ceaebd01b830432f5b9ae0448222831ef349c6775243db4c9c5898c5e9L23-R28): Updated the class to use the `IrisConfig` object instead of the `IrisRabbitMQConfig` object, resulting in changes to the constructor and the `buildConnectionFactory()` method. [[1]](diffhunk://#diff-af0b87ceaebd01b830432f5b9ae0448222831ef349c6775243db4c9c5898c5e9L23-R28) [[2]](diffhunk://#diff-af0b87ceaebd01b830432f5b9ae0448222831ef349c6775243db4c9c5898c5e9L12-R12) [[3]](diffhunk://#diff-af0b87ceaebd01b830432f5b9ae0448222831ef349c6775243db4c9c5898c5e9L40-R40)
* [`extension/runtime/src/main/java/org/iris_events/runtime/configuration/IrisBuildTimeConfig.java`](diffhunk://#diff-301a7d09eaabfff8c7753eea7034fd14e8d9752428ec7ff0328e167e1b28efa9L7-R8): Renamed the class `IrisBuildConfiguration` to `IrisBuildTimeConfig`.
* [`extension/runtime/src/main/java/org/iris_events/producer/EventProducer.java`](diffhunk://#diff-39c1791500a2791b9fa0497cd1338366a1d9690d20fa34598d97e8c9a6c186f9L50-R50): Updated the import statement and constructor to use `IrisConfig` instead of `IrisRabbitMQConfig`, and replaced the `IrisRabbitMQConfig` field with `IrisConfig`. [[1]](diffhunk://#diff-39c1791500a2791b9fa0497cd1338366a1d9690d20fa34598d97e8c9a6c186f9L50-R50) [[2]](diffhunk://#diff-39c1791500a2791b9fa0497cd1338366a1d9690d20fa34598d97e8c9a6c186f9L92-R92) [[3]](diffhunk://#diff-39c1791500a2791b9fa0497cd1338366a1d9690d20fa34598d97e8c9a6c186f9L73-R73)
* `extension/runtime/src/main/java/org/iris_events/runtime/connection/AbstractConnectionProvider.java`: Renamed the `IrisRabbitMQConfig` class to `IrisConfig`, and updated the related import statements and constructor. (F2a7bb30)
* `extension/runtime/src/main/java/org/iris_events/runtime/configuration/IrisConfig.java`: Renamed the `IrisRabbitMQConfig` class to `IrisConfig` and updated the configuration properties related to RabbitMQ. (F392d549)
* [`extension/runtime/src/main/java/org/iris_events/runtime/channel/AbstractChannelService.java`](diffhunk://#diff-80ed39a362bd8b6437bff0115afd96a9d5ec278a8e4fb06a9c96811ec225d5f7L9-R9): Updated the import statement and field to use `IrisConfig` instead of `IrisRabbitMQConfig`. [[1]](diffhunk://#diff-80ed39a362bd8b6437bff0115afd96a9d5ec278a8e4fb06a9c96811ec225d5f7L9-R9) [[2]](diffhunk://#diff-80ed39a362bd8b6437bff0115afd96a9d5ec278a8e4fb06a9c96811ec225d5f7L22-R28)
* [`extension/runtime/src/main/java/org/iris_events/runtime/connection/ConsumerConnectionProvider.java`](diffhunk://#diff-94752792dd7b7a0eca8a8d98e63bd5d89071359ea6a7378d6a8541e6f1b20979L9-R9): Updated the class to use the renamed `IrisConfig` class instead of `IrisRabbitMQConfig`. [[1]](diffhunk://#diff-94752792dd7b7a0eca8a8d98e63bd5d89071359ea6a7378d6a8541e6f1b20979L9-R9) [[2]](diffhunk://#diff-94752792dd7b7a0eca8a8d98e63bd5d89071359ea6a7378d6a8541e6f1b20979L20-R20)

Please note that due to the length and complexity of the changes, only the most important ones have been included in this list.