### PR TITLE
Added new x-client-version header key to Message headers constants

### DIFF
--- a/common/src/main/java/org/iris_events/common/MessagingHeaders.java
+++ b/common/src/main/java/org/iris_events/common/MessagingHeaders.java
@@ -24,6 +24,8 @@ public class MessagingHeaders {
         public static final String SUBSCRIPTION_ID = "x-subscription-id";
         public static final String CORRELATION_ID = "x-correlation-id";
         public static final String CACHE_TTL = "x-cache-ttl";
+
+        public static final String CLIENT_VERSION = "x-client-version";
     }
 
     public static class RequeueMessage {


### PR DESCRIPTION
This pull request to the `common` module adds a new constant `CLIENT_VERSION` to the `MessagingHeaders` class in `MessagingHeaders.java` to represent the header key for the client version in the messaging system.

Main change:

* [`common/src/main/java/org/iris_events/common/MessagingHeaders.java`](diffhunk://#diff-b4bb52e123f21abeefdd50c4b43d27ce3417dc79b06a144c8294dd66ad7a0e0aR27-R28): Added a new constant `CLIENT_VERSION` to the `MessagingHeaders` class.