### PR TITLE
Make sure iris provided token is properly resolved in all cases

### DIFF
--- a/extension/deployment/pom.xml
+++ b/extension/deployment/pom.xml
@@ -37,12 +37,8 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-reactive-messaging-rabbitmq-deployment</artifactId>
+            <artifactId>quarkus-security-deployment</artifactId>
         </dependency>
-        <!--<dependency>
-            <groupId>io.apicurio</groupId>
-            <artifactId>apicurio-codegen-quarkus-extension-deployment</artifactId>
-        </dependency>-->
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>

--- a/extension/deployment/src/main/java/org/iris_events/deployment/IrisProcessor.java
+++ b/extension/deployment/src/main/java/org/iris_events/deployment/IrisProcessor.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import jakarta.annotation.Nullable;
+
 import org.iris_events.annotations.Scope;
 import org.iris_events.auth.IrisJwtValidator;
 import org.iris_events.consumer.ConsumerContainer;
@@ -42,7 +44,6 @@ import org.iris_events.runtime.recorder.RpcMappingRecorder;
 import org.iris_events.runtime.requeue.MessageRequeueHandler;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Type;
-import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/extension/integration-tests/pom.xml
+++ b/extension/integration-tests/pom.xml
@@ -25,6 +25,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-jwt-build</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-mockito</artifactId>
             <scope>test</scope>
@@ -32,6 +36,11 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-test-security-jwt</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/extension/integration-tests/src/test/java/org/iris_events/it/auth/JwtAuthIT.java
+++ b/extension/integration-tests/src/test/java/org/iris_events/it/auth/JwtAuthIT.java
@@ -70,6 +70,16 @@ public class JwtAuthIT extends AbstractIntegrationTest {
 
     @DisplayName("Resolve valid JWT")
     @Test
+    /*
+     * @TestSecurity(user = "userJwt", roles = "AUTHENTICATED")
+     *
+     * @JwtSecurity(claims = {
+     *
+     * @Claim(key = "sub", value = "008b048c-817f-4d57-bd8c-cc567381d422"),
+     *
+     * @Claim(key = "globalid", value = "john")
+     * })
+     */
     void resolveJwt() throws Exception {
         final var token = TokenUtils.generateTokenString("/AuthenticatedToken.json");
         final var message = new JwtAuthMessage(UUID.randomUUID().toString());
@@ -137,6 +147,7 @@ public class JwtAuthIT extends AbstractIntegrationTest {
     @DisplayName("Throw exception on invalid claim")
     @ParameterizedTest
     @EnumSource(value = TokenUtils.InvalidClaims.class, names = { "EXP", "ISSUER", "SIGNER", "ALG" })
+
     void expiredToken() throws Exception {
         final var token = TokenUtils.generateTokenString("/AuthenticatedToken.json", Set.of(TokenUtils.InvalidClaims.EXP));
         final var message = new JwtAuthMessage(UUID.randomUUID().toString());

--- a/extension/runtime/pom.xml
+++ b/extension/runtime/pom.xml
@@ -47,8 +47,12 @@
             <artifactId>quarkus-smallrye-jwt</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-smallrye-reactive-messaging-rabbitmq</artifactId>
+            <groupId>org.eclipse.microprofile.jwt</groupId>
+            <artifactId>microprofile-jwt-auth-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.common</groupId>
+            <artifactId>smallrye-common-vertx-context</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.inject</groupId>

--- a/extension/runtime/src/main/java/org/iris_events/auth/IrisJsonWebTokenProducer.java
+++ b/extension/runtime/src/main/java/org/iris_events/auth/IrisJsonWebTokenProducer.java
@@ -1,0 +1,41 @@
+package org.iris_events.auth;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.jwt.JsonWebToken;
+import org.jboss.logging.Logger;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import io.smallrye.jwt.auth.cdi.NullJsonWebToken;
+
+@Priority(5)
+@Alternative
+@RequestScoped
+public class IrisJsonWebTokenProducer {
+    private static final Logger LOG = Logger.getLogger(IrisJsonWebTokenProducer.class);
+
+    @Inject
+    SecurityIdentity identity;
+
+    /**
+     * The producer method for the current access token
+     *
+     * @return the access token
+     */
+    @Produces
+    @RequestScoped
+    JsonWebToken currentAccessToken() {
+        if (identity.isAnonymous()) {
+            return new NullJsonWebToken();
+        }
+        if (identity.getPrincipal() instanceof JsonWebToken) {
+            return (JsonWebToken) identity.getPrincipal();
+        }
+        throw new IllegalStateException("Current principal " + identity.getPrincipal() + " is not a JSON web token");
+    }
+
+}

--- a/extension/runtime/src/main/java/org/iris_events/auth/IrisJwtValidator.java
+++ b/extension/runtime/src/main/java/org/iris_events/auth/IrisJwtValidator.java
@@ -17,9 +17,9 @@ import org.slf4j.LoggerFactory;
 import io.quarkus.security.AuthenticationFailedException;
 import io.quarkus.security.ForbiddenException;
 import io.quarkus.security.UnauthorizedException;
+import io.quarkus.security.credential.TokenCredential;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.security.runtime.QuarkusSecurityIdentity;
-import io.quarkus.smallrye.jwt.runtime.auth.JsonWebTokenCredential;
 import io.smallrye.jwt.auth.principal.JWTParser;
 import io.smallrye.jwt.auth.principal.ParseException;
 
@@ -68,7 +68,7 @@ public class IrisJwtValidator {
 
     private SecurityIdentity createSecurityIdentity(final String jwtToken) {
         try {
-            JsonWebTokenCredential jsonWebTokenCredential = new JsonWebTokenCredential(jwtToken);
+            TokenCredential jsonWebTokenCredential = new TokenCredential(jwtToken, "bearer");
             JsonWebToken jwtPrincipal = this.parser.parse(jwtToken);
             return QuarkusSecurityIdentity.builder()
                     .setPrincipal(jwtPrincipal)

--- a/maven/model-generator-plugin/src/main/java/org/iris_events/plugin/model/generator/AmqpGenerator.java
+++ b/maven/model-generator-plugin/src/main/java/org/iris_events/plugin/model/generator/AmqpGenerator.java
@@ -227,7 +227,7 @@ public class AmqpGenerator {
     }
 
     private void rewriteRefsInSchemaFiles(Path schemasPath) {
-        log.info("Rewriting refs in schema files...");
+        log.debug("Rewriting refs in schema files...");
         try {
             HashMap<String, String> schemaNamesToLocation = new HashMap<>();
 
@@ -240,7 +240,7 @@ public class AmqpGenerator {
             try (var schemas = Files.list(schemasPath)) {
                 schemas.map(Path::toFile)
                         .forEach(file -> {
-                            log.info("Iterating to file " + file.getName());
+                            log.debug("Iterating to file " + file.getName());
                             if (file.isFile()) {
                                 String fileContent = fileInteractor.readFile(Path.of(file.toURI()));
                                 schemaNamesToLocation.entrySet().stream()
@@ -251,12 +251,12 @@ public class AmqpGenerator {
             }
 
             //rewrite base schemas
-            log.info("Rewriting base schemas");
+            log.debug("Rewriting base schemas");
             Stream.concat(Files.list(schemasPath), Files.list(schemasPath.resolve(StringConstants.PAYLOAD)))
                     .map(Path::toFile)
                     .filter(File::isFile)
                     .forEach(this::replaceAllRefs);
-            log.info("Done rewriting base schemas");
+            log.debug("Done rewriting base schemas");
         } catch (IOException e) {
             log.error("Problem rewriting refs in schema files!");
             throw new RuntimeException(e);
@@ -380,7 +380,7 @@ public class AmqpGenerator {
     }
 
     private void replaceAllRefs(File file) {
-        log.info("Replacing all refs in file " + file.getAbsolutePath());
+        log.debug("Replacing all refs in file " + file.getAbsolutePath());
         String fileContent = fileInteractor.readFile(Path.of(file.toURI()));
         while (fileContent.contains(StringConstants.REF)) {
             Matcher matcher = REF_PATTERN.matcher(fileContent);
@@ -391,7 +391,7 @@ public class AmqpGenerator {
                         .reduce((first, second) -> second).orElse(StringConstants.EMPTY_STRING);
                 final var replacementForRef = AmqpStringUtils.getReplacementForRef(name, packageName,
                         AmqpStringUtils.getPackageName(modelName));
-                log.info("Replacing. To replace = " + toReplace + " replacement for ref = " + replacementForRef);
+                log.debug("Replacing. To replace = " + toReplace + " replacement for ref = " + replacementForRef);
                 fileContent = fileContent.replace(toReplace,
                         replacementForRef);
             } else {


### PR DESCRIPTION
This pull request primarily focuses on updating dependencies and modifying code to accommodate these changes in the `extension` module. The changes include swapping out the `quarkus-smallrye-reactive-messaging-rabbitmq` dependency for `quarkus-security-deployment` and `microprofile-jwt-auth-api`, adding `smallrye-jwt-build` and `quarkus-test-security-jwt` dependencies for testing, and updating import statements and method calls to match the updated dependencies. Additionally, there are changes to improve logging in the `maven/model-generator-plugin` module.

Dependency updates:

* [`extension/deployment/pom.xml`](diffhunk://#diff-4844fd01d3dafaea80119ddbec3483de2858403008a9e70218b57f0598d80cb0L40-L45): Replaced `quarkus-smallrye-reactive-messaging-rabbitmq-deployment` dependency with `quarkus-security-deployment`.
* [`extension/integration-tests/pom.xml`](diffhunk://#diff-17959e8b7bb58b79d9007f9df785db3765453bba5620371fb3429ed34a64fa2eR27-R30): Added `smallrye-jwt-build` and `quarkus-test-security-jwt` dependencies for testing. [[1]](diffhunk://#diff-17959e8b7bb58b79d9007f9df785db3765453bba5620371fb3429ed34a64fa2eR27-R30) [[2]](diffhunk://#diff-17959e8b7bb58b79d9007f9df785db3765453bba5620371fb3429ed34a64fa2eR41-R45)
* [`extension/runtime/pom.xml`](diffhunk://#diff-5549ec02914cc245ffcdff0d5327e40d7e0abfdcda4a2e2fc26a2a02f5e638ceL50-R55): Replaced `quarkus-smallrye-reactive-messaging-rabbitmq` dependency with `microprofile-jwt-auth-api` and `smallrye-common-vertx-context`.

Code modifications to match updated dependencies:

* [`extension/deployment/src/main/java/org/iris_events/deployment/IrisProcessor.java`](diffhunk://#diff-31d0c92c67f9d5872de1ff32a5827d397f4291f5fd371854732c38ab40e05777R8-R9): Updated import statements to match the new dependencies. [[1]](diffhunk://#diff-31d0c92c67f9d5872de1ff32a5827d397f4291f5fd371854732c38ab40e05777R8-R9) [[2]](diffhunk://#diff-31d0c92c67f9d5872de1ff32a5827d397f4291f5fd371854732c38ab40e05777L45)
* [`extension/runtime/src/main/java/org/iris_events/auth/IrisJwtValidator.java`](diffhunk://#diff-c00593ea7850225a54af6a5d0a5042b2cb86ac93e874d1fd38edac74cf289beeR20-L22): Updated method calls to match the new dependencies. [[1]](diffhunk://#diff-c00593ea7850225a54af6a5d0a5042b2cb86ac93e874d1fd38edac74cf289beeR20-L22) [[2]](diffhunk://#diff-c00593ea7850225a54af6a5d0a5042b2cb86ac93e874d1fd38edac74cf289beeL71-R71)
* [`extension/runtime/src/main/java/org/iris_events/consumer/DeliverCallbackProvider.java`](diffhunk://#diff-589194bbc4608f9c69c0c5f01ad2b13e95e544e8a68ef52b1a7a2f9d240d8c65L32-R34): Updated import statements and method calls to match the new dependencies. [[1]](diffhunk://#diff-589194bbc4608f9c69c0c5f01ad2b13e95e544e8a68ef52b1a7a2f9d240d8c65L32-R34) [[2]](diffhunk://#diff-589194bbc4608f9c69c0c5f01ad2b13e95e544e8a68ef52b1a7a2f9d240d8c65L75-R88)

Logging improvements:

* [`maven/model-generator-plugin/src/main/java/org/iris_events/plugin/model/generator/AmqpGenerator.java`](diffhunk://#diff-5886bb1c7382e582ec9ddddb65c789bc5d651015352c64ee9eb377366bf15793L230-R230): Changed logging level from `info` to `debug` for more granular logging. [[1]](diffhunk://#diff-5886bb1c7382e582ec9ddddb65c789bc5d651015352c64ee9eb377366bf15793L230-R230) [[2]](diffhunk://#diff-5886bb1c7382e582ec9ddddb65c789bc5d651015352c64ee9eb377366bf15793L243-R243) [[3]](diffhunk://#diff-5886bb1c7382e582ec9ddddb65c789bc5d651015352c64ee9eb377366bf15793L254-R259) [[4]](diffhunk://#diff-5886bb1c7382e582ec9ddddb65c789bc5d651015352c64ee9eb377366bf15793L383-R383) [[5]](diffhunk://#diff-5886bb1c7382e582ec9ddddb65c789bc5d651015352c64ee9eb377366bf15793L394-R394)