### PR TITLE
fix maven plugin schema generation

### DIFF
--- a/asyncapi/implementation/src/main/java/org/iris_events/asyncapi/runtime/io/AsyncApiSerializer.java
+++ b/asyncapi/implementation/src/main/java/org/iris_events/asyncapi/runtime/io/AsyncApiSerializer.java
@@ -2,6 +2,7 @@ package org.iris_events.asyncapi.runtime.io;
 
 import java.io.IOException;
 
+import io.apicurio.datamodels.Library;
 import org.iris_events.asyncapi.runtime.json.IrisObjectMapper;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -31,12 +32,13 @@ public class AsyncApiSerializer {
     public static String serialize(AsyncApi26Document asyncApi, Format format) throws IOException {
         try {
             ObjectMapper mapper;
+            var schema = Library.writeDocument(asyncApi);
             if (format == Format.JSON) {
                 mapper = IrisObjectMapper.getObjectMapper();
-                return mapper.writeValueAsString(asyncApi);
+                return mapper.writeValueAsString(schema);
             } else {
                 mapper = IrisObjectMapper.getYamlObjectMapper();
-                return mapper.writer().writeValueAsString(asyncApi);
+                return mapper.writer().writeValueAsString(schema);
             }
         } catch (JsonProcessingException e) {
             throw new IOException(e);

--- a/asyncapi/implementation/src/test/java/org/iris_events/asyncapi/runtime/scanner/IrisAnnotationScannerTest.java
+++ b/asyncapi/implementation/src/test/java/org/iris_events/asyncapi/runtime/scanner/IrisAnnotationScannerTest.java
@@ -96,6 +96,7 @@ public class IrisAnnotationScannerTest extends IndexScannerTestBase {
         final var documentJsonNode = Library.writeDocument(document);
         final var schemaString = IrisObjectMapper.getObjectMapper().writerWithDefaultPrettyPrinter()
                 .writeValueAsString(documentJsonNode);
+        System.out.println("Generated schema:\n" + schemaString);
         JSONAssert.assertEquals("Json contents should match", expectedContent, schemaString, JSONCompareMode.NON_EXTENSIBLE);
     }
 


### PR DESCRIPTION
This pull request primarily involves updates to the `asyncapi` package, which is used for creating, manipulating, and serializing AsyncAPI documents. The changes aim to improve the serialization process, modify the way channels are created, and update the way the schema is written in the `GenerateSchemaMojo.java` file. 

Here are the most important changes:

Serialization improvements:
* [`asyncapi/implementation/src/main/java/org/iris_events/asyncapi/runtime/io/AsyncApiSerializer.java`](diffhunk://#diff-36e737b5bcc32ea6b9bf877b16f3ec28129a7d2334057c7b218a82bf0a4e1f04R5): The `Library` class from `io.apicurio.datamodels` is now imported and used to write the AsyncAPI document into a schema. This schema is then serialized instead of the original AsyncAPI document. [[1]](diffhunk://#diff-36e737b5bcc32ea6b9bf877b16f3ec28129a7d2334057c7b218a82bf0a4e1f04R5) [[2]](diffhunk://#diff-36e737b5bcc32ea6b9bf877b16f3ec28129a7d2334057c7b218a82bf0a4e1f04R35-R41)

Channel creation modifications:
* [`asyncapi/implementation/src/main/java/org/iris_events/asyncapi/runtime/scanner/BaseAnnotationScanner.java`](diffhunk://#diff-aa53a44cd4cb1381e2bcbcab366b17bf3712117c636c7df45ed360ffebd71865R10): The `createChannels` method has been significantly changed. Instead of creating a new `AsyncApi26ChannelsImpl` instance, it now retrieves or creates the channels from the provided document. The `AsyncApi26OperationImpl` and `AsyncApi26OperationBindingsImpl` instances are also replaced with instances created from the `channelItem` and `operation` respectively. Additionally, the existing channels are no longer added to the new channels. [[1]](diffhunk://#diff-aa53a44cd4cb1381e2bcbcab366b17bf3712117c636c7df45ed360ffebd71865R10) [[2]](diffhunk://#diff-aa53a44cd4cb1381e2bcbcab366b17bf3712117c636c7df45ed360ffebd71865L99-R117) [[3]](diffhunk://#diff-aa53a44cd4cb1381e2bcbcab366b17bf3712117c636c7df45ed360ffebd71865L151-L159)

Schema writing updates:
* [`maven/asyncapi-generator-plugin/src/main/java/org/iris_events/plugin/asyncapi/generator/GenerateSchemaMojo.java`](diffhunk://#diff-3584709fe929e4dad851ac446084c604eb1f6b0086c6df34c043bcf61a495eefR16-R17): The `Library` class is used to write the AsyncAPI document into a schema before it is written into a file or printed to stdout. The `writeSchemaFile` method now accepts an `ObjectNode` instead of an `AsyncApi26Document`. The order of the `write` and `uploadToApicurio` methods in the `execute` method has also been changed. [[1]](diffhunk://#diff-3584709fe929e4dad851ac446084c604eb1f6b0086c6df34c043bcf61a495eefR16-R17) [[2]](diffhunk://#diff-3584709fe929e4dad851ac446084c604eb1f6b0086c6df34c043bcf61a495eefL177-L181) [[3]](diffhunk://#diff-3584709fe929e4dad851ac446084c604eb1f6b0086c6df34c043bcf61a495eefL243-R245) [[4]](diffhunk://#diff-3584709fe929e4dad851ac446084c604eb1f6b0086c6df34c043bcf61a495eefL253) [[5]](diffhunk://#diff-3584709fe929e4dad851ac446084c604eb1f6b0086c6df34c043bcf61a495eefL264-R270)

Minor changes:
* [`asyncapi/implementation/src/main/java/org/iris_events/asyncapi/runtime/scanner/BaseAnnotationScanner.java`](diffhunk://#diff-aa53a44cd4cb1381e2bcbcab366b17bf3712117c636c7df45ed360ffebd71865L198-R194): The `setResponseType` method now accepts an `AsyncApiOperation` instead of an `AsyncApi26Operation`.
* [`asyncapi/implementation/src/test/java/org/iris_events/asyncapi/runtime/scanner/IrisAnnotationScannerTest.java`](diffhunk://#diff-e50bdbc8baff3cddf9aba8a6c470bed3ab9ceb0eced9d618e2f8c90d3fb88f80R99): The generated schema is now printed to stdout.