### PR TITLE
reset correlation id only when sending msg to specific user

### DIFF
--- a/extension/runtime/src/main/java/org/iris_events/runtime/BasicPropertiesProvider.java
+++ b/extension/runtime/src/main/java/org/iris_events/runtime/BasicPropertiesProvider.java
@@ -104,11 +104,15 @@ public class BasicPropertiesProvider {
 
         final var builder = basicProperties.builder();
         if (userId != null || sessionId != null) {
-            builder.correlationId(correlationIdProvider.getCorrelationId());
             headers.put(ORIGIN_SERVICE_ID, serviceId);
-            headers.remove(ROUTER);
 
-            Optional.ofNullable(userId).ifPresent(id -> headers.put(USER_ID, id));
+            Optional.ofNullable(userId).ifPresent(id -> {
+                // reset correlationId only in case when sending to specific user (to not break RPC contract on router)
+                builder.correlationId(correlationIdProvider.getCorrelationId());
+                // we want all router instances to get the message, because we don't know which one holds the user session
+                headers.remove(ROUTER);
+                headers.put(USER_ID, id);
+            });
             Optional.ofNullable(sessionId).ifPresent(id -> headers.put(SESSION_ID, id));
         }
 


### PR DESCRIPTION
Extension was resetting the correlation id for every message where `sessionId` was present - essentially for every message which was a side effect of a client websocket message.
This caused that iris-router could not find the returning events to client to match the "request".