### PR TITLE
revisit correlationId handling to not reset it automatically

### DIFF
--- a/common/src/main/java/org/iris_events/common/ErrorMessageDetailsBuilder.java
+++ b/common/src/main/java/org/iris_events/common/ErrorMessageDetailsBuilder.java
@@ -16,20 +16,24 @@ public class ErrorMessageDetailsBuilder {
     public static ErrorMessageDetails build(
             final String originalMessageExchange,
             final Map<String, Object> currentMessageHeaders,
+            final String currentServiceId,
             final long currentTimestamp) {
 
         final var exchange = Exchanges.ERROR.getValue();
         final var routingKey = getRoutingKey(originalMessageExchange);
-        final var messageHeaders = buildMessageHeaders(currentMessageHeaders, currentTimestamp);
+        final var messageHeaders = buildMessageHeaders(currentMessageHeaders, currentServiceId, currentTimestamp);
 
         return new ErrorMessageDetails(exchange, routingKey, messageHeaders);
     }
 
     private static Map<String, Object> buildMessageHeaders(final Map<String, Object> currentMessageHeaders,
-            final long currentTimestamp) {
+            String currentServiceId, final long currentTimestamp) {
         final var messageHeaders = new HashMap<>(currentMessageHeaders);
         messageHeaders.remove(MessagingHeaders.Message.JWT);
+        messageHeaders.put(MessagingHeaders.Message.ORIGIN_EVENT_TYPE,
+                currentMessageHeaders.get(MessagingHeaders.Message.EVENT_TYPE));
         messageHeaders.put(MessagingHeaders.Message.EVENT_TYPE, Exchanges.ERROR.getValue());
+        messageHeaders.put(MessagingHeaders.Message.CURRENT_SERVICE_ID, currentServiceId);
         messageHeaders.put(MessagingHeaders.Message.SERVER_TIMESTAMP, currentTimestamp);
 
         return messageHeaders;

--- a/common/src/main/java/org/iris_events/common/MessagingHeaders.java
+++ b/common/src/main/java/org/iris_events/common/MessagingHeaders.java
@@ -12,6 +12,7 @@ public class MessagingHeaders {
         public static final String DEVICE = "x-device";
         public static final String CLIENT_TRACE_ID = "x-client-trace-id";
         public static final String EVENT_TYPE = "x-event-type";
+        public static final String ORIGIN_EVENT_TYPE = "x-origin-event-type";
         public static final String SESSION_ID = "x-session-id";
         public static final String USER_ID = "x-user-id";
         public static final String ROUTER = "x-router";

--- a/extension/integration-tests/src/test/java/org/iris_events/it/producer/EventProducerTest.java
+++ b/extension/integration-tests/src/test/java/org/iris_events/it/producer/EventProducerTest.java
@@ -1,11 +1,9 @@
 package org.iris_events.it.producer;
 
-import static org.iris_events.common.MessagingHeaders.Message.CURRENT_SERVICE_ID;
 import static org.iris_events.common.MessagingHeaders.Message.EVENT_TYPE;
 import static org.iris_events.common.MessagingHeaders.Message.INSTANCE_ID;
 import static org.iris_events.common.MessagingHeaders.Message.SERVER_TIMESTAMP;
 import static org.iris_events.common.MessagingHeaders.Message.USER_ID;
-import static org.iris_events.producer.EventProducer.SERVICE_ID_UNAVAILABLE_FALLBACK;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -194,7 +192,6 @@ public class EventProducerTest {
             final boolean propagate,
             final DeliveryMode deliveryMode) {
         final Map<String, Object> headers = new HashMap<>();
-        headers.put(CURRENT_SERVICE_ID, SERVICE_ID_UNAVAILABLE_FALLBACK);
         headers.put(INSTANCE_ID, INSTANCE_NAME);
         headers.put(EVENT_TYPE, eventName);
         headers.put(SERVER_TIMESTAMP, CURRENT_TIMESTAMP);

--- a/extension/runtime/src/main/java/org/iris_events/producer/EventProducer.java
+++ b/extension/runtime/src/main/java/org/iris_events/producer/EventProducer.java
@@ -63,7 +63,6 @@ import com.rabbitmq.client.ReturnListener;
 public class EventProducer {
     private static final Logger log = LoggerFactory.getLogger(EventProducer.class);
 
-    public static final String SERVICE_ID_UNAVAILABLE_FALLBACK = "N/A";
     private static final long WAIT_TIMEOUT_MILLIS = 2000;
     private static final String RESOURCE = "resource";
 

--- a/extension/runtime/src/main/java/org/iris_events/producer/RoutingDetails.java
+++ b/extension/runtime/src/main/java/org/iris_events/producer/RoutingDetails.java
@@ -12,14 +12,13 @@ public final class RoutingDetails {
     private final String routingKey;
     private final Scope scope;
     private final String userId;
-    private final String sessionId;
     private final String subscriptionId;
     private final boolean persistent;
     private final Integer cacheTtl;
     private final boolean propagate;
 
     public RoutingDetails(final String eventName, final String exchange, final ExchangeType exchangeType,
-            final String routingKey, final Scope scope, final String userId, final String sessionId,
+            final String routingKey, final Scope scope, final String userId,
             final String subscriptionId, final boolean persistent, final Integer cacheTtl, final boolean propagate) {
         this.eventName = eventName;
         this.exchange = exchange;
@@ -27,7 +26,6 @@ public final class RoutingDetails {
         this.routingKey = routingKey;
         this.scope = scope;
         this.userId = userId;
-        this.sessionId = sessionId;
         this.subscriptionId = subscriptionId;
         this.persistent = persistent;
         this.cacheTtl = cacheTtl;
@@ -56,10 +54,6 @@ public final class RoutingDetails {
 
     public String getUserId() {
         return userId;
-    }
-
-    public String getSessionId() {
-        return sessionId;
     }
 
     public String getSubscriptionId() {
@@ -93,14 +87,13 @@ public final class RoutingDetails {
                 exchange, that.exchange) && exchangeType == that.exchangeType && Objects.equals(routingKey,
                         that.routingKey)
                 && scope == that.scope && Objects.equals(userId, that.userId)
-                && Objects.equals(sessionId, that.sessionId) && Objects.equals(subscriptionId,
-                        that.subscriptionId)
+                && Objects.equals(subscriptionId, that.subscriptionId)
                 && Objects.equals(cacheTtl, that.cacheTtl);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(eventName, exchange, exchangeType, routingKey, scope, userId, sessionId, subscriptionId, persistent,
+        return Objects.hash(eventName, exchange, exchangeType, routingKey, scope, userId, subscriptionId, persistent,
                 cacheTtl);
     }
 
@@ -210,11 +203,6 @@ public final class RoutingDetails {
             return this;
         }
 
-        public MiscRoutingDetailsBuilder sessionId(final String sessionId) {
-            this.sessionId = sessionId;
-            return this;
-        }
-
         public MiscRoutingDetailsBuilder subscriptionId(final String subscriptionId) {
             this.subscriptionId = subscriptionId;
             return this;
@@ -236,7 +224,7 @@ public final class RoutingDetails {
         }
 
         public RoutingDetails build() {
-            return new RoutingDetails(eventName, exchange, exchangeType, routingKey, scope, userId, sessionId, subscriptionId,
+            return new RoutingDetails(eventName, exchange, exchangeType, routingKey, scope, userId, subscriptionId,
                     persistent, cacheTtl, propagate);
         }
     }

--- a/extension/runtime/src/main/java/org/iris_events/routing/RoutingDetailsProvider.java
+++ b/extension/runtime/src/main/java/org/iris_events/routing/RoutingDetailsProvider.java
@@ -56,17 +56,11 @@ public class RoutingDetailsProvider {
                 .exchangeType(ExchangeType.TOPIC)
                 .routingKey(routingKey)
                 .scope(scope)
+                // message should be sent to specific user (not necessarily the same as current user)
                 .userId(userId)
                 .persistent(persistent);
 
-        final var optionalSessionId = eventContext.getSessionId();
-        final var optionalUserId = eventContext.getUserId();
-
-        optionalSessionId.ifPresent(builder::sessionId);
-        optionalUserId.ifPresent(builder::userId);
-
-        return builder
-                .build();
+        return builder.build();
     }
 
     public RoutingDetails getRoutingDetailsFromAnnotation(final org.iris_events.annotations.Message messageAnnotation,

--- a/extension/runtime/src/main/java/org/iris_events/runtime/BasicPropertiesProvider.java
+++ b/extension/runtime/src/main/java/org/iris_events/runtime/BasicPropertiesProvider.java
@@ -63,10 +63,16 @@ public class BasicPropertiesProvider {
      * @return AmqpBasicProperties
      */
     public AMQP.BasicProperties getOrCreateAmqpBasicProperties(final RoutingDetails routingDetails) {
-        final var eventAppContext = Optional.ofNullable(eventAppInfoProvider.getEventAppContext());
-        final var serviceId = eventAppContext.map(EventAppContext::getId).orElse(SERVICE_ID_UNAVAILABLE_FALLBACK);
-        final var basicProperties = Optional.ofNullable(eventContext.getAmqpBasicProperties())
-                .orElse(createAmqpBasicProperties(serviceId));
+        String serviceId = SERVICE_ID_UNAVAILABLE_FALLBACK;
+        final EventAppContext eventAppContext = eventAppInfoProvider.getEventAppContext();
+        if (eventAppContext != null) {
+            serviceId = eventAppContext.getId();
+        }
+        AMQP.BasicProperties basicProperties = eventContext.getAmqpBasicProperties();
+        if (basicProperties == null) {
+            log.debug("No basic properties found within eventContext - building new one.");
+            basicProperties = createAmqpBasicProperties(serviceId);
+        }
 
         return buildAmqpBasicPropertiesWithCustomHeaders(basicProperties, serviceId, routingDetails);
     }

--- a/extension/runtime/src/main/java/org/iris_events/runtime/EventAppInfoProvider.java
+++ b/extension/runtime/src/main/java/org/iris_events/runtime/EventAppInfoProvider.java
@@ -21,6 +21,6 @@ public class EventAppInfoProvider {
     }
 
     public String getApplicationId() {
-        return eventAppContext.getId();
+        return eventAppContext != null ? eventAppContext.getId() : null;
     }
 }

--- a/extension/runtime/src/main/java/org/iris_events/runtime/IrisExceptionHandler.java
+++ b/extension/runtime/src/main/java/org/iris_events/runtime/IrisExceptionHandler.java
@@ -41,18 +41,21 @@ public class IrisExceptionHandler {
     private final EventContext eventContext;
     private final MessageRequeueHandler retryEnqueuer;
     private final TimestampProvider timestampProvider;
+    private final EventAppInfoProvider eventAppInfoProvider;
 
     @Inject
     public IrisExceptionHandler(
             final ObjectMapper objectMapper,
             final EventContext eventContext,
             final MessageRequeueHandler retryEnqueuer,
-            final TimestampProvider timestampProvider) {
+            final TimestampProvider timestampProvider,
+            EventAppInfoProvider eventAppInfoProvider) {
 
         this.objectMapper = objectMapper;
         this.eventContext = eventContext;
         this.retryEnqueuer = retryEnqueuer;
         this.timestampProvider = timestampProvider;
+        this.eventAppInfoProvider = eventAppInfoProvider;
     }
 
     public void handleException(final IrisContext irisContext, final Delivery message, final Channel channel,
@@ -161,6 +164,7 @@ public class IrisExceptionHandler {
         final var errorMessageDetails = ErrorMessageDetailsBuilder
                 .build(originalExchange,
                         originalMessageHeaders,
+                        eventAppInfoProvider.getApplicationId(),
                         currentTimestamp);
 
         final var messageHeaders = errorMessageDetails.messageHeaders();

--- a/extension/runtime/src/test/java/org/iris_events/runtime/exception/IrisExceptionHandlerTest.java
+++ b/extension/runtime/src/test/java/org/iris_events/runtime/exception/IrisExceptionHandlerTest.java
@@ -9,6 +9,7 @@ import jakarta.validation.ConstraintViolationException;
 
 import org.iris_events.context.EventContext;
 import org.iris_events.context.IrisContext;
+import org.iris_events.runtime.EventAppInfoProvider;
 import org.iris_events.runtime.IrisExceptionHandler;
 import org.iris_events.runtime.TimestampProvider;
 import org.iris_events.runtime.requeue.MessageRequeueHandler;
@@ -36,7 +37,7 @@ class IrisExceptionHandlerTest {
         MessageRequeueHandler messageRequeueHandler = Mockito.mock();
         TimestampProvider timestampProvider = Mockito.mock();
         exceptionHandler = new IrisExceptionHandler(new ObjectMapper(), new EventContext(), messageRequeueHandler,
-                timestampProvider);
+                timestampProvider, new EventAppInfoProvider());
     }
 
     @Test


### PR DESCRIPTION
# Title: Refactor BasicPropertiesProvider and RoutingDetails classes

## Description
This PR introduces changes largely to two main classes: `BasicPropertiesProvider` and `RoutingDetails`.

### Key Changes
- Revisit `BasicPropertiesProvider.java` for send to user case to reset routing headers only when message is sent to another user.
- Removed automatic reset of the `correlationId` as it may break correlation of events within the backend.
- The `RoutingDetails` class was updated to remove `sessionId` related methods and code because we do not support send to specific session and is no need for setting `sessionId` in routing details.
- `EventProducerTest` class was updated accordingly to reflect these changes in `BasicPropertiesProvider` and `RoutingDetails` classes.

### Impact
The changes are expected to improve the accuracy and reliability of event handling and prevent loosing `correlationId` on returning events.